### PR TITLE
Update RuntimeLiveQueryExecutor.cs

### DIFF
--- a/Microsoft.ReportViewer.Common/Microsoft.ReportingServices.OnDemandProcessing/RuntimeLiveQueryExecutor.cs
+++ b/Microsoft.ReportViewer.Common/Microsoft.ReportingServices.OnDemandProcessing/RuntimeLiveQueryExecutor.cs
@@ -247,13 +247,31 @@ namespace Microsoft.ReportingServices.OnDemandProcessing
 		{
 			try
 			{
-				if (m_dataSet.Query.TimeOut == 0 && command is CommandWrapper && ((CommandWrapper)command).UnderlyingCommand is SqlCommand)
+				// Following code loads SqlClient DLL [System.Data.SqlClient.dll]
+				//if (m_dataSet.Query.TimeOut == 0 && command is CommandWrapper && ((CommandWrapper)command).UnderlyingCommand is SqlCommand)
+				//{
+				//	command.CommandTimeout = 2147483646;
+				//}
+				//else
+				if (m_dataSet.Query.TimeOut == 0 && command is CommandWrapper cw)
 				{
-					command.CommandTimeout = 2147483646;
+					if (couldSqlCommandTimeOut(cw))
+						return;
 				}
-				else
+				// Fallback
 				{
 					command.CommandTimeout = m_dataSet.Query.TimeOut;
+				}
+				
+				bool couldSqlCommandTimeOut(CommandWrapper cw)
+				{
+					if (cw.UnderlyingCommand is SqlCommand)
+					{
+						command.CommandTimeout = 2147483646;
+						return true;
+					}
+
+					return false;
 				}
 			}
 			catch (Exception innerException)


### PR DESCRIPTION
Proposed changes prevent the reference to System.Data.SqlClient.dll and runtimes\win\lib\netcoreapp2.1\System.Data.SqlClient.dll.
This allows to reduce the footprint of published binaries.