### PR TITLE
Update ControlPolicyManager.cs

### DIFF
--- a/Microsoft.ReportViewer.Common/Microsoft.Reporting/ControlPolicyManager.cs
+++ b/Microsoft.ReportViewer.Common/Microsoft.Reporting/ControlPolicyManager.cs
@@ -4,9 +4,6 @@ using Microsoft.ReportingServices.ReportProcessing.ReportObjectModel;
 using System;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Security;
-using System.Security.Permissions;
-using System.Security.Policy;
 
 namespace Microsoft.Reporting
 {


### PR DESCRIPTION
Removed the name spaces to allow it to compile with .NET 6.
The Evidence was ambiguous between Security and Reporting name spaces.