### PR TITLE
Add error identification for failed ReportItem rendering

### DIFF
--- a/Microsoft.ReportViewer.Common/Microsoft.ReportingServices.Rendering.DataRenderer/StringResources.cs
+++ b/Microsoft.ReportViewer.Common/Microsoft.ReportingServices.Rendering.DataRenderer/StringResources.cs
@@ -117,6 +117,8 @@ internal class StringResources
 
 	public static string rrDuplicatedBatchItem => Keys.GetString("rrDuplicatedBatchItem");
 
+	public static string rrRenderReportItemError => Keys.GetString("rrRenderReportItemError");
+
 	protected StringResources()
 	{
 	}

--- a/Microsoft.ReportViewer.Common/Microsoft.ReportingServices.Rendering.DataRenderer/StringResources.resx
+++ b/Microsoft.ReportViewer.Common/Microsoft.ReportingServices.Rendering.DataRenderer/StringResources.resx
@@ -46,4 +46,5 @@
   <data name="rrInvalidParamValue"><value>The value of the parameter '{0}' is not valid (rrInvalidParamValue).</value></data>
   <data name="LocalizedCsvRendererName"><value>CSV (comma delimited)</value></data>
   <data name="rrCanNotLoadXSLT"><value>Cannot load XSLT specified at ‘{0}’ (rrCanNotLoadXSLT).</value></data>
+  <data name="rrRenderReportItemError" xml:space="preserve"><value>ReportItem ‘{0}’ could not be rendered (rrRenderReportItemError). </value></data>
   </root>

--- a/Microsoft.ReportViewer.Common/Microsoft.ReportingServices.Rendering.HPBProcessing/PageItemContainer.cs
+++ b/Microsoft.ReportViewer.Common/Microsoft.ReportingServices.Rendering.HPBProcessing/PageItemContainer.cs
@@ -225,10 +225,17 @@ namespace Microsoft.ReportingServices.Rendering.HPBProcessing
 				for (int i = 0; i < childrenDef.Count; i++)
 				{
 					ReportItem source = childrenDef[i];
-					m_children[i] = PageItem.Create(source, tablixCellParent: false, pageContext);
-					m_indexesLeftToRight[i] = i;
-					num = Math.Max(num, m_children[i].ItemPageSizes.Right);
-					num2 = Math.Max(num2, m_children[i].ItemPageSizes.Bottom);
+					try
+					{
+						m_children[i] = PageItem.Create(source, tablixCellParent: false, pageContext);
+						m_indexesLeftToRight[i] = i;
+						num = Math.Max(num, m_children[i].ItemPageSizes.Right);
+						num2 = Math.Max(num2, m_children[i].ItemPageSizes.Bottom);
+					}
+					catch
+					{
+						throw new ReportRenderingException(string.Format(StringResources.rrRenderReportItemError, source.Name));
+					}
 				}
 				double num3 = 0.0;
 				num3 = ((!pageContext.ConsumeWhitespace) ? Math.Max(num2, base.ItemPageSizes.Height) : num2);


### PR DESCRIPTION
This pull request enhances error reporting in `PageItemContainer.CreateChildren()` by adding a try-catch block around the creation of each child PageItem. When a rendering error occurs, the exception now includes the name of the problematic ReportItem, making it easier to diagnose rendering issues.