### PR TITLE
fix: use GetExecutingAssembly instead of GetCallingAssembly for AOT compatibility

### DIFF
--- a/Microsoft.ReportViewer.NETCore/Microsoft.Reporting.NETCore/LocalReport.cs
+++ b/Microsoft.ReportViewer.NETCore/Microsoft.Reporting.NETCore/LocalReport.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Reporting.NETCore
 				{
 					if (string.Compare(value, ReportEmbeddedResource, StringComparison.Ordinal) != 0)
 					{
-						SetEmbeddedResourceAsReportDefinition(value, Assembly.GetCallingAssembly());
+						SetEmbeddedResourceAsReportDefinition(value, RuntimeFeature.IsDynamicCodeSupported ? Assembly.GetCallingAssembly() : Assembly.GetExecutingAssembly());
 					}
 				}
 			}

--- a/Microsoft.ReportViewer.WinForms/Microsoft.Reporting.WinForms/LocalReport.cs
+++ b/Microsoft.ReportViewer.WinForms/Microsoft.Reporting.WinForms/LocalReport.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Reporting.WinForms
 				{
 					if (string.Compare(value, ReportEmbeddedResource, StringComparison.Ordinal) != 0)
 					{
-						SetEmbeddedResourceAsReportDefinition(value, Assembly.GetCallingAssembly());
+						SetEmbeddedResourceAsReportDefinition(value, RuntimeFeature.IsDynamicCodeSupported ? Assembly.GetCallingAssembly() : Assembly.GetExecutingAssembly());
 					}
 				}
 			}


### PR DESCRIPTION
AOT environments do not support Assembly.GetCallingAssembly(), so use Assembly.GetExecutingAssembly() instead to ensure compatibility.

https://github.com/dotnet/runtime/issues/94200