### PR TITLE
Adding Kerberos support

### DIFF
--- a/Microsoft.ReportViewer.NETCore/Microsoft.Reporting.NETCore.Internal.Soap.ReportingServices2005.Execution/ReportExecutionServiceSoapClientExtension.cs
+++ b/Microsoft.ReportViewer.NETCore/Microsoft.Reporting.NETCore.Internal.Soap.ReportingServices2005.Execution/ReportExecutionServiceSoapClientExtension.cs
@@ -21,10 +21,14 @@ namespace Microsoft.Reporting.NETCore.Internal.Soap.ReportingServices2005.Execut
 				var cred = value.GetCredential(null, null);
 				ClientCredentials.Windows.ClientCredential.UserName = cred.UserName;
 				ClientCredentials.Windows.ClientCredential.Password = cred.Password;
-				ClientCredentials.Windows.AllowedImpersonationLevel = System.Security.Principal.TokenImpersonationLevel.Delegation;
+                if (cred.Domain != null && cred.Domain.Length > 0)
+                {
+                    ClientCredentials.Windows.ClientCredential.Domain = cred.Domain;
+                }
+                ClientCredentials.Windows.AllowedImpersonationLevel = System.Security.Principal.TokenImpersonationLevel.Delegation;
 				var binding = (BasicHttpBinding)Endpoint.Binding;
 				binding.Security.Mode = Endpoint.Address.Uri.Scheme == "https" ? BasicHttpSecurityMode.Transport : BasicHttpSecurityMode.TransportCredentialOnly;
-				binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Ntlm;
+				binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
 			}
 		}
 

--- a/Microsoft.ReportViewer.WinForms/Microsoft.Reporting.WinForms.Internal.Soap.ReportingServices2005.Execution/ReportExecutionServiceSoapClientExtension.cs
+++ b/Microsoft.ReportViewer.WinForms/Microsoft.Reporting.WinForms.Internal.Soap.ReportingServices2005.Execution/ReportExecutionServiceSoapClientExtension.cs
@@ -21,10 +21,14 @@ namespace Microsoft.Reporting.WinForms.Internal.Soap.ReportingServices2005.Execu
 				var cred = value.GetCredential(null, null);
 				ClientCredentials.Windows.ClientCredential.UserName = cred.UserName;
 				ClientCredentials.Windows.ClientCredential.Password = cred.Password;
-				ClientCredentials.Windows.AllowedImpersonationLevel = System.Security.Principal.TokenImpersonationLevel.Delegation;
+                if (cred.Domain != null && cred.Domain.Length > 0)
+                {
+                    ClientCredentials.Windows.ClientCredential.Domain = cred.Domain;
+                }
+                ClientCredentials.Windows.AllowedImpersonationLevel = System.Security.Principal.TokenImpersonationLevel.Delegation;
 				var binding = (BasicHttpBinding)Endpoint.Binding;
 				binding.Security.Mode = Endpoint.Address.Uri.Scheme == "https" ? BasicHttpSecurityMode.Transport : BasicHttpSecurityMode.TransportCredentialOnly;
-				binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Ntlm;
+				binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
 			}
 		}
 


### PR DESCRIPTION
As Microsoft is depreciating NTLM and NTLM isn't very secure and is a common target in cyberattacks, this updates the authentication mechanism to HttpClientCredentialType.Windows which is the equivalent of negotiate authentication which will normally favor Kerberos if available but fail back to NTLM if not available.